### PR TITLE
derive PartialEq to support assert_eq! in dependent project unit tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ use serde_valid::Validate;
 use std::fmt;
 
 /// Resume Schema
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Resume {
@@ -67,7 +67,7 @@ pub struct Resume {
 	pub meta: Option<Meta>,
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Basics {
@@ -89,7 +89,7 @@ pub struct Basics {
 	pub profiles: Vec<Profile>,
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Location {
@@ -106,7 +106,7 @@ pub struct Location {
 }
 
 /// Specify any number of social networks that you participate in
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Profile {
@@ -118,7 +118,7 @@ pub struct Profile {
 	pub url: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Work {
@@ -153,7 +153,7 @@ pub struct Work {
 }
 
 /// e.g. Increased profits by 20% from 2011-2012 through viral advertising
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 pub struct Highlight(pub String);
 
@@ -163,7 +163,7 @@ impl fmt::Display for Highlight {
 	}
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Volunteer {
@@ -195,7 +195,7 @@ pub struct Volunteer {
 	pub highlights: Vec<Highlight>,
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Education {
@@ -232,7 +232,7 @@ pub struct Education {
 }
 
 /// e.g. H1302 - Introduction to American history
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 pub struct Course(pub String);
 
@@ -243,7 +243,7 @@ impl fmt::Display for Course {
 }
 
 /// Specify any awards you have received throughout your professional caree
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Award {
@@ -263,7 +263,7 @@ pub struct Award {
 }
 
 /// Specify any certificates you have received throughout your professional career
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Certificate {
@@ -278,7 +278,7 @@ pub struct Certificate {
 }
 
 /// Specify your publications through your career
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Publication {
@@ -301,7 +301,7 @@ pub struct Publication {
 }
 
 /// List out your professional skill-set
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Skill {
@@ -314,7 +314,7 @@ pub struct Skill {
 }
 
 /// e.g. HTML
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 pub struct Keyword(pub String);
 
@@ -325,7 +325,7 @@ impl fmt::Display for Keyword {
 }
 
 /// List any other languages you speak
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Language {
@@ -335,7 +335,7 @@ pub struct Language {
 	pub fluency: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Interest {
@@ -345,7 +345,7 @@ pub struct Interest {
 }
 
 /// List references you have received
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Reference {
@@ -356,7 +356,7 @@ pub struct Reference {
 }
 
 /// Specify career projects
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Project {
@@ -395,7 +395,7 @@ pub struct Project {
 }
 
 /// e.g. Team Lead, Speaker, Writer
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 pub struct Role(pub String);
 
@@ -406,7 +406,7 @@ impl fmt::Display for Role {
 }
 
 /// The schema version and any other tooling configuration lives here
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "validate", derive(Validate))]
 #[serde(default)]
 pub struct Meta {


### PR DESCRIPTION
I've recently begun using this project to implement a resume generator and wanted to use `assert_eq!` in unit tests to validate my own json and yaml test data fixtures stay synchronized as I update the test data fixture content.

This PR is necessary for that.
